### PR TITLE
improved caching

### DIFF
--- a/v2/client/public/serviceWorker.js
+++ b/v2/client/public/serviceWorker.js
@@ -5,7 +5,7 @@ const self = this;
 
 const baseURL = '/slidechat';
 const cachePattern = /^(?!chrome-extension).*(?:\.css|\.js|\.ico|\.woff2|\.html)$/;
-const tempCachePattern = /(?:\/api\/slideImg|\/api\/slideThumbnail)/;
+const slideCachePattern = /(?:\/api\/slideImg|\/api\/slideThumbnail)\?slideID=([0-9a-f]{24})&/;
 
 self.addEventListener('install', (e) => {
 	console.log('service worker installed');
@@ -43,11 +43,14 @@ self.addEventListener('fetch', (e) => {
 	let whichCache;
 	if (cachePattern.test(e.request.url)) {
 		whichCache = CACHE_NAME;
-	} else if (tempCachePattern.test(e.request.url)) {
-		whichCache = TEMP_CACHE_NAME;
 	} else {
-		e.respondWith(fetch(e.request));
-		return;
+		const match = e.request.url.match(slideCachePattern);
+		if (match) {
+			whichCache = `SlideChat-slide-${match[1]}`;
+		} else {
+			e.respondWith(fetch(e.request));
+			return;
+		}
 	}
 	e.respondWith(
 		caches.open(whichCache).then((cache) => {

--- a/v2/client/src/index.js
+++ b/v2/client/src/index.js
@@ -14,7 +14,6 @@ if (window.navigator.serviceWorker) {
 		navigator.serviceWorker
 			.register(`${process.env.PUBLIC_URL}/serviceWorker.js`)
 			.then((reg) => console.log(`service worker registered with scope "${reg.scope}"`))
-			.then(() => caches.delete('SlideChat-temp'))
 			.catch((err) => console.error(err));
 	});
 } else {

--- a/v2/routes/commonAPI.js
+++ b/v2/routes/commonAPI.js
@@ -84,6 +84,7 @@ function commonAPI(db, io, isInstructor) {
 				isInstructor: course.instructors.indexOf(req.session.uid) >= 0,
 				drawable: slide.drawable,
 				downloadable: !slide.notAllowDownload,
+				updated: slide.updated,
 			});
 		} catch (err) {
 			errorHandler(res, err);

--- a/v2/routes/instructorAPI.js
+++ b/v2/routes/instructorAPI.js
@@ -464,6 +464,7 @@ function instructorAPI(db, io, instructorAuth, isInstructor) {
 			let oldLength = pages.length;
 			let newLength = imagePaths.length;
 			let updateRes;
+			const updateTime = Date.now();
 			if (oldLength > newLength) {
 				// remove empty pages
 				let i = newLength;
@@ -481,6 +482,7 @@ function instructorAPI(db, io, instructorAuth, isInstructor) {
 							pages: pages.slice(0, newLength),
 							pageTotal: newLength,
 							filename: req.files.file.name,
+							updated: updateTime,
 						},
 						$push: {
 							unused: {
@@ -501,6 +503,7 @@ function instructorAPI(db, io, instructorAuth, isInstructor) {
 							pages: pages,
 							pageTotal: newLength,
 							filename: req.files.file.name,
+							updated: updateTime,
 						},
 					}
 				);


### PR DESCRIPTION
For each file, store the file update time (if it is updated, otherwise undefined), send it along with /api/slideInfo
In the client, store the time cache for each file is created in localStorage (as a stringified JSON). When fetching slideInfo, for the current file, check if cache creation time is older than the file update time, if so delete. For every file, check if cache creation time is 7 days, if so delete. Visiting a file refreshes the cache creation time.
Back compatibility: last file updated time would be undefined, (cacheCreationTime < undefined) gives false, so don't need to handle it